### PR TITLE
[FE] 연동 테스트 - 로그인, 헤더

### DIFF
--- a/src/main/webapp/app/pages/login/login.tsx
+++ b/src/main/webapp/app/pages/login/login.tsx
@@ -88,6 +88,12 @@ class Login extends React.Component<ILoginProps, ILoginState> {
         });
     };
 
+    enterPassword = (e: React.KeyboardEvent) => {
+        if (e.key.toUpperCase() === 'ENTER') {
+            this.handleLogin();
+        }
+    };
+
     changePassword = e => {
         this.setState({
             password: e.target.value
@@ -96,6 +102,8 @@ class Login extends React.Component<ILoginProps, ILoginState> {
 
     render() {
         const { classes } = this.props;
+        const hostname = window.location.host;
+
         return (
             <Grid
                 container
@@ -108,9 +116,7 @@ class Login extends React.Component<ILoginProps, ILoginState> {
                     <Card className={ classNames(classes.form) }>
                         <CardContent>
                             <Typography className={ classNames(classes.loginHeader) }>자바카페에 로그인</Typography>
-                            <Typography
-                                className={ classNames(classes.loginSubHeader) }>javacafe.cryptoband.com
-                            </Typography>
+                            <Typography className={ classNames(classes.loginSubHeader) }>{hostname}</Typography>
                             <FormControl
                                 fullWidth
                             >
@@ -131,6 +137,7 @@ class Login extends React.Component<ILoginProps, ILoginState> {
                                     placeholder="패스워드"
                                     type="password"
                                     className={ classNames(classes.input) }
+                                    onKeyDown={this.enterPassword}
                                     onChange={ this.changePassword }
                                 />
                             </FormControl>
@@ -160,7 +167,6 @@ const mapDispatchToProps = { login };
 type StateProps = ReturnType<typeof mapStateToProps>;
 type DispatchProps = typeof mapDispatchToProps;
 
-// @ts-ignore
 export default connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/main/webapp/app/shared/layout/menudrawer/menudrawer.tsx
+++ b/src/main/webapp/app/shared/layout/menudrawer/menudrawer.tsx
@@ -102,7 +102,7 @@ const styles = theme => createStyles({
     profile: {
       width: '50px',
       height: '50px',
-      'border-radius': '3px'
+      'border-radius': '50%'
     }
 });
 
@@ -118,6 +118,33 @@ interface IDrawerState {
 
 interface IDrawerProps extends StateProps, DispatchProps, WithStyles, RouteComponentProps {
 }
+
+const defaultAvatar = classes =>
+    (
+        <img
+            className={ classes.profile }
+            src={ '/content/images/default-avatar.png' }
+        />
+    );
+
+const profileImageElement = ({ classes, account }) => {
+    if (!account.avatar) {
+        return defaultAvatar(classes);
+    }
+
+    const userImage = new Image();
+    userImage.onerror = () => {
+        return defaultAvatar(classes);
+    };
+    userImage.src = account.avatar;
+
+    return (
+        <img
+            className={ classes.profile }
+            src={ account.avatar }
+        />
+    );
+};
 
 class MenuDrawer extends React.Component<IDrawerProps, IDrawerState> {
     state: IDrawerState = {
@@ -167,10 +194,10 @@ class MenuDrawer extends React.Component<IDrawerProps, IDrawerState> {
                     <div>
                         <IconButton aria-owns={ open ? 'menu-appbar' : undefined } aria-haspopup="true"
                                     onClick={ this.handleMenu } color="inherit">
-                            <img
-                                className={ classes.profile }
-                                src={ this.props.account.avatar }
-                            />
+                            {
+                                profileImageElement(this.props)
+                            }
+
                         </IconButton>
                     </div>
                 </Toolbar>


### PR DESCRIPTION
### 로그인
- 패스워드 입력 창 엔터 키 입력 시 로그인 처리
- 상단 URL host로 변경
### 헤더
- 프로필 이미지 404 시 기본 이미지
- 프로필 영역 동그랗게 변경