### PR TITLE
[#110] 페이지에 따라 그룹명, 이벤트 명으로 title 변경

### DIFF
--- a/src/main/webapp/app/index.tsx
+++ b/src/main/webapp/app/index.tsx
@@ -13,11 +13,13 @@ import ErrorBoundary from './shared/error/error-boundary';
 import AppComponent from './app';
 import { loadIcons } from './config/icon-loader';
 
+import { getGroup  } from 'app/pages/group/groups.reducer';
+
 const devTools = process.env.NODE_ENV === 'development' ? <DevTools /> : null;
 const store = initStore();
 registerLocale(store);
 
-const actions = bindActionCreators({ clearAuthentication, getSession }, store.dispatch);
+const actions = bindActionCreators({ clearAuthentication, getSession, getGroup }, store.dispatch);
 setupAxiosInterceptors(() => actions.clearAuthentication('login.error.unauthorized'));
 
 loadIcons();
@@ -26,6 +28,9 @@ const rootEl = document.getElementById('root');
 
 const render = async Component => {
     await actions.getSession();
+    // todo 서비스 오픈 시 groupId를 받아올 방법에 대한 정리가 필요
+    await actions.getGroup(1);
+    window.document.title = store.getState().groups.group.name || 'chainity';
     ReactDOM.render(
         <ErrorBoundary>
             <AppContainer>

--- a/src/main/webapp/app/pages/events/event/event-detail.tsx
+++ b/src/main/webapp/app/pages/events/event/event-detail.tsx
@@ -133,8 +133,14 @@ export class EventDetailPage extends React.Component<IEventDetailPageProp> {
         this.props.history.push('/event');
     };
 
+    componentWillUnmount(): void {
+        const { group } = this.props;
+        window.document.title = group.name;
+    }
+
     render() {
-        const { user, classes, event, rewards } = this.props;
+        const { user, classes, event, rewards, group } = this.props;
+        window.document.title = (`${group.name} - ${event.title}`) || group.name;
 
         console.log('event', event);
         console.log('user', user);
@@ -158,7 +164,8 @@ const mapStateToProps = storeState => ({
     participations: storeState.event.participations,
     event: storeState.event.event,
     rewards: storeState.event.rewards,
-    user: storeState.users.user
+    user: storeState.users.user,
+    group: storeState.groups.group
 });
 
 const mapDispatchToProps = { getSession, getEvent, getEventParticipations, getEventRewards, getUser };

--- a/src/main/webapp/app/pages/group/groups.reducer.ts
+++ b/src/main/webapp/app/pages/group/groups.reducer.ts
@@ -8,7 +8,9 @@ export const ACTION_TYPES = {
 
 const initialState = {
     loading: false,
-    group: {},
+    group: {
+        name: ''
+    },
     errorMessage: ''
 };
 
@@ -40,7 +42,9 @@ export default (state: GroupsState = initialState, action): GroupsState => {
 };
 
 // Actions
-export const getGroup = groupId => ({
-    type: ACTION_TYPES.GET_GROUP,
-    payload: axios.get(`v1/groups/${groupId}`)
-});
+export const getGroup = groupId => async dispatch => {
+    await dispatch({
+        type: ACTION_TYPES.GET_GROUP,
+        payload: axios.get(`v1/groups/${groupId}`)
+    });
+};


### PR DESCRIPTION
- 로그인 페이지 진입 시 그룹 정보를 가져와 홈페이지 title 설정
- 이벤트 상세 진입 시 이벤트 명을 title에 추가

* 링크 공유 시(3rd-party 서비스 공유(rich social sharing)의 경우 봇이 자바스크립트를 실행하지 않는다고 합니다.  
해결 책은 몇 가지가 있지만 기능 추가정도의 작업이 아니고 프로젝트 전체를 다시 작업하는 정도의 공수가 소요 될 것 같습니다.
  1. 서버 사이드 랜더링
  2. 특정 페이지만 서버 랜더링(봇 접근 시 redirect)
  3. [사전 랜더링](https://prerender.io/)

* 참고자료
  - [Open Graph protocol](https://ogp.me/): Rich Social Sharing 서비스 대상에서 접근하는 정보 
  - [Enable Rich Social Sharing in Your AngularJS App](https://www.michaelbromley.co.uk/blog/enable-rich-social-sharing-in-your-angularjs-app/)