### PR TITLE
이벤트 상세보기시 생성자 정보 불러오기 실패 #296

### DIFF
--- a/src/main/webapp/app/pages/events/event/event-detail.tsx
+++ b/src/main/webapp/app/pages/events/event/event-detail.tsx
@@ -119,11 +119,10 @@ export interface IEventDetailPageProp extends StateProps, DispatchProps, RouteCo
 
 export class EventDetailPage extends React.Component<IEventDetailPageProp> {
 
-    componentDidMount() {
+    async componentDidMount() {
         const eventId = queryString.parse(this.props.location.search).id;
-        this.props.getEvent('1', eventId);
-        // TODO 유저정보 조회시 status, role 파라미터가 필수로 되어있음. 이벤트 상세정보에서 어떠한 사용자가 생성한 정보인지 조회시에는 불필요한정보임. 임시로 고정처리
-        this.props.getUser('1', this.props.event.createdBy, 'active', 'system');
+        await this.props.getEvent('1', eventId);
+        this.props.getUser('1', this.props.event.createdBy);
         this.props.getEventParticipations('1', eventId);
         this.props.getEventRewards('1', eventId);
 
@@ -142,11 +141,11 @@ export class EventDetailPage extends React.Component<IEventDetailPageProp> {
         const { user, classes, event, rewards, group } = this.props;
         window.document.title = (`${group.name} - ${event.title}`) || group.name;
 
-        console.log('event', event);
-        console.log('user', user);
-        console.dir(this.props);
+        //console.log('event', event);
+        //console.log('user', user);
+        //console.dir(this.props);
 
-        console.log(classes[ 'history-back-btn' ]);
+        //console.log(classes[ 'history-back-btn' ]);
         return (
             <div>
                 { gridContainer(classes, 9, 3, event, rewards, user, queryString.parse(this.props.location.search).id) }

--- a/src/main/webapp/app/pages/profile/profile.tsx
+++ b/src/main/webapp/app/pages/profile/profile.tsx
@@ -82,7 +82,7 @@ export class ProfilePage extends React.Component<IProfileProp, IProfileState> {
 
     componentDidMount() {
         const { account } = this.props;
-        this.props.getUser('1', account._id, account.status, account.role);
+        this.props.getUser('1', account._id);
         this.props.getEventParticipationByUser('1', account._id);
     }
 

--- a/src/main/webapp/app/pages/users/users.reducer.ts
+++ b/src/main/webapp/app/pages/users/users.reducer.ts
@@ -58,9 +58,9 @@ export const getUsers = groupId => ({
     payload: axios.get(`v1/groups/${groupId}/users`)
 });
 
-export const getUser = (groupId, userId, status, role) => ({
+export const getUser = (groupId, userId) => ({
     type: ACTION_TYPES.GET_USER,
-    payload: axios.get(`v1/groups/${groupId}/users/${userId}?status=${status}&role=${role}`)
+    payload: axios.get(`v1/groups/${groupId}/users/${userId}`)
 });
 
 // export const createUser: ICrudPutAction<IUser> = user => async dispatch => {


### PR DESCRIPTION
- 이벤트 정보값이 전달된 이후에 이벤트 생성자 정보를 불러오도록 수정
- 사용자 정보 조회 시 deprecated 된 파라미터 제거